### PR TITLE
add support for django's enum types

### DIFF
--- a/src/enum_prop/base.py
+++ b/src/enum_prop/base.py
@@ -7,12 +7,21 @@ from typing import Generic
 from typing import Mapping
 from typing import TypeVar
 
+from django.db import models
+
+import inspect
+
 K = TypeVar("K")
 V = TypeVar("V")
 
 
 class EnumDict(dict[K, V], Generic[K, V]):
     def __getitem__(self, item: K | Enum) -> V:
+        if isinstance(item, models.IntegerChoices) or isinstance(item, models.TextChoices):
+            try:
+                return super().__getitem__((item.value,))
+            except KeyError:
+                return super().__getitem__((item.value, item.label))
         if isinstance(item, Enum):
             return super().__getitem__(item.value)
         return super().__getitem__(item)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,6 +6,7 @@ import pytest
 
 from enum_prop import enum_property
 
+from django.db.models import IntegerChoices, TextChoices
 
 def test_can_define_property() -> None:
     class A(enum.Enum):
@@ -29,3 +30,23 @@ def test_incomplete_mapping_raises_attribute_error() -> None:
 
     with pytest.raises(AttributeError, match=r"B.b has no attribute 'val'"):
         B.b.val
+
+
+def test_django_choices():
+    class D(TextChoices):
+        LOW = "one", "test"
+        MEDIUM = "two",
+        HIGH = "three",
+        colour = enum_property({LOW: "green", MEDIUM: "yellow", HIGH: "red"})
+
+    assert D.LOW.colour == "green"
+    assert D.MEDIUM.colour == "yellow"
+
+    class E(IntegerChoices):
+        LOW = 1, "test"
+        MEDIUM = 2,
+        HIGH = 3,
+        colour = enum_property({LOW: "green", MEDIUM: "yellow", HIGH: "red"})
+
+    assert D.LOW.colour == "green"
+    assert D.MEDIUM.colour == "yellow"


### PR DESCRIPTION
Seems like a reasonable idea, doesn't take much to support it. I don't know much about this project, is it meant to be used exclusively with django? If not, this makes django a dependency, and thus is a breaking change. A separate django module might be more interesting in that case. If it is, then this closes #3.